### PR TITLE
disoriented title rectified

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "core-js": "^2.4.1",
     "crypto": "0.0.3",
     "debug": "~2.6.3",
+    "email-verify": "^0.2.1",
     "express": "~4.15.2",
     "express-session": "^1.15.3",
     "hammerjs": "^2.0.8",

--- a/src/app/malaria-101/activity-2/activity-2.component.scss
+++ b/src/app/malaria-101/activity-2/activity-2.component.scss
@@ -1,4 +1,4 @@
-@import "../styles/main";
+@import "../../styles/main";
 
 .available-item{
     padding: $padding-med;

--- a/src/app/menu/menu.component.html
+++ b/src/app/menu/menu.component.html
@@ -1,4 +1,4 @@
-<div class="col-md-12 text-center"><h2 class="stage-header">{{language?.menu.heading}}</h2></div>
+<div class="col-md-5 pull-right"><h2 class="stage-header">{{language?.menu.heading}}</h2></div>
 <div class="menu">
     <div class="col-lg-6 col-xs-offset-3">
         <div class="row">


### PR DESCRIPTION
**Description**
 The title Main Menu appeared disoriented in the introduction page.

Fixes # [ISSUE]
#78 Disoriented Title

**Type of Change**
- Bootstrap tag changed to bring the title in position

**Mocks**
![image](https://user-images.githubusercontent.com/22315151/36913301-77785002-1e6f-11e8-951f-a7eeb145aacd.png)
